### PR TITLE
v2.0.0

### DIFF
--- a/include/parser.hpp
+++ b/include/parser.hpp
@@ -186,12 +186,12 @@ public:
 				{
 					if (storedKey == key)
 					{
-						toLower(storedValue);
-						if (contains(trueValues, storedValue))
+						std::string storedValue_ = toLower(storedValue);
+						if (contains(trueValues, storedValue_))
 						{
 							return true;
 						}
-						if (contains(falseValues, storedValue))
+						if (contains(falseValues, storedValue_))
 						{
 							return false;
 						}

--- a/include/parser.hpp
+++ b/include/parser.hpp
@@ -1,14 +1,27 @@
+// Ini Parser for Modern C++
+// Version 2.0.0
+// https://github.com/liner-exe/IniParser
+// 2024-2024 liner-exe
+// License: MIT
+
+
 #ifndef INI_PARSER_LINEREXE
 #define INI_PARSER_LINEREXE
 
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <map>
+#include <vector>
+#include <algorithm>
 
 class IniParser
 {
-	std::map <std::string, std::map<std::string, std::string>> m_data;
+public:
+	using KeyValuePair = std::pair<std::string, std::string>;
+	using Section = std::pair<std::string, std::vector<KeyValuePair>>;
+
+private:
+	std::vector<Section> m_data;
 
 	static void trim(std::string& str)
 	{
@@ -22,16 +35,26 @@ class IniParser
 		const size_t last = str.find_last_not_of(" \t\r\n");
 		str = str.substr(first, last - first + 1);
 	}
+
+	static std::string toLower(const std::string &str)
+	{
+		std::string result = str;
+		std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+		return result;
+	}
+
+	static bool contains(const std::vector<std::string>& vec, const std::string& sub)
+	{
+		return std::find(vec.begin(), vec.end(), sub) != vec.end();
+	}
+
 public:
 	void read(const std::string& filename)
 	{
 		std::ifstream file(filename);
 
-		std::map<std::string, std::string> innerData;
-		std::string line;
-		std::string section;
-		std::string key;
-		std::string value;
+		std::vector<KeyValuePair> innerData;
+		std::string line, section;
 
 		while (getline(file, line))
 		{
@@ -41,29 +64,36 @@ public:
 				continue;
 			}
 
-			size_t openBracketPos = line.find('[');
-			size_t closeBracketPos = line.find(']');
+			const size_t openBracketPos = line.find('[');
+			const size_t closeBracketPos = line.find(']');
 
 			if (openBracketPos == std::string::npos)
 			{
 				size_t equalSign = line.find('=');
-				key = line.substr(0, equalSign);
-				value = line.substr(equalSign + 1);
+				std::string key = line.substr(0, equalSign);
+				std::string value = line.substr(equalSign + 1);
 
 				trim(key);
 				trim(value);
 
-				innerData[key] = value;
+				innerData.emplace_back(key, value);
 				continue;
 			}
 
 			if (!section.empty())
 			{
-				m_data[section] = innerData;
+				m_data.emplace_back(section, innerData);
 				innerData.clear();
 			}
 
 			section = line.substr(openBracketPos + 1, closeBracketPos - 1);
+			trim(section);
+		}
+
+		if (!section.empty())
+		{
+			m_data.emplace_back(section, innerData);
+			innerData.clear();
 		}
 
 		file.close();
@@ -71,7 +101,134 @@ public:
 
 	std::string get(const std::string& section, const std::string& key)
 	{
-		return m_data[section][key];
+		for (const auto& [storedSection, storedKeyValuePair] : m_data)
+		{
+			if (storedSection == section)
+			{
+				for (const auto& [storedKey, storedValue] : storedKeyValuePair)
+				{
+					if (storedKey == key)
+					{
+						return storedValue;
+					}
+				}
+			}
+		}
+
+		return "-1";
+	}
+
+	std::vector<std::string> getSectionNames()
+	{
+		std::vector<std::string> result;
+
+		for (const auto& [storedSection, storedKeyValuePair] : m_data)
+		{
+			result.push_back(storedSection);
+		}
+
+		return result;
+	}
+
+	std::vector<KeyValuePair> getSectionData(const std::string& section) const
+	{
+		for (const auto& [storedSection, storedKeyValuePair] : m_data)
+		{
+			if (storedSection == section) {
+				return storedKeyValuePair;
+			}
+		}
+
+		throw std::invalid_argument("Section not found");
+	}
+
+	bool hasSection(const std::string &sectionName) const
+	{
+		for (const auto& [storedSection, storedKeyValuePair] : m_data) {
+			if (storedSection == sectionName)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	bool hasKey(const std::string& section, const std::string& key)
+	{
+		for (const auto& [storedSection, storedKeyValuePair] : m_data)
+		{
+			if (storedSection == section)
+			{
+				for (const auto& [storedKey, storedValue] : storedKeyValuePair)
+				{
+					if (storedKey == key)
+					{
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+
+	bool getBoolean(const std::string& section, const std::string& key)
+	{
+		std::vector<std::string> trueValues { "1", "yes", "true", "on" };
+		std::vector<std::string> falseValues { "0", "no", "false", "off" };
+
+		for (const auto& [storedSection, storedKeyValuePair] : m_data)
+		{
+			if (storedSection == section)
+			{
+				for (const auto& [storedKey, storedValue] : storedKeyValuePair)
+				{
+					if (storedKey == key)
+					{
+						toLower(storedValue);
+						if (contains(trueValues, storedValue))
+						{
+							return true;
+						}
+						if (contains(falseValues, toLower(storedValue)))
+						{
+							return false;
+						}
+					}
+				}
+			}
+		}
+
+		throw std::invalid_argument("Can't get boolean");
+	}
+
+	int getInteger(const std::string& section, const std::string& key)
+	{
+		for (const auto& [storedSection, storedKeyValuePair] : m_data)
+		{
+			if (storedSection == section)
+			{
+				for (const auto& [storedKey, storedValue] : storedKeyValuePair)
+				{
+					if (storedKey == key)
+					{
+						try
+						{
+							return std::stoi(storedValue);
+						} catch (const std::invalid_argument&)
+						{
+							throw std::invalid_argument("Invalid integer value");
+						} catch (const std::out_of_range&)
+						{
+							throw std::invalid_argument("Integer value out of range");
+						}
+					}
+				}
+			}
+		}
+
+		return -1;
 	}
 
 	void show() const

--- a/include/parser.hpp
+++ b/include/parser.hpp
@@ -191,7 +191,7 @@ public:
 						{
 							return true;
 						}
-						if (contains(falseValues, toLower(storedValue)))
+						if (contains(falseValues, storedValue))
 						{
 							return false;
 						}


### PR DESCRIPTION
# v2.0.0
- Fixed wrong fetching of sectors (#2 by @liner-exe)
- Added new method: getSectorNames, which displays all available sectors
- Added new method: getSectionData, which allows you to fetch data from desired sector
- Added getInteger & getBoolean methods (#4 by @liner-exe)
- Added hasSector & hasKey methods (#5 by @liner-exe)
- Now elements store in proper order (#3 by @liner-exe)